### PR TITLE
Fix "no method getsitepackages" when installing in virtualenv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -251,7 +251,12 @@ def copy_custom_sqlite3():
     try:
         import site
         cp_from = INTERNAL + '/'
-        for sitepack in site.getsitepackages():
+        if hasattr(site, 'getsitepackages'):
+            site_packages = site.getsitepackages()
+        else:
+            from distutils.sysconfig import get_python_lib
+            site_packages = [get_python_lib()]
+        for sitepack in site_packages:
             globbed = glob(sitepack + '/pymagnitude*/')
             try:
                 cp_to = globbed[0] + '/pymagnitude/third_party/internal/'


### PR DESCRIPTION
This PR attempts to fix magnitude installation inside a virtualenv. See https://github.com/pypa/virtualenv/issues/228
I've tested this fix with Python 3.7.0