### PR TITLE
Fixing test flakiness

### DIFF
--- a/pymagnitude/third_party/allennlp/tests/modules/seq2seq_encoders/multi_head_self_attention_test.py
+++ b/pymagnitude/third_party/allennlp/tests/modules/seq2seq_encoders/multi_head_self_attention_test.py
@@ -41,4 +41,4 @@ class MultiHeadSelfAttentionTest(AllenNlpTestCase):
         # only the unmasked elements - should be the same.
         result_without_mask = attention(tensor[:, :6, :])
         numpy.testing.assert_almost_equal(result[0, :6, :].detach().cpu().numpy(),
-                                          result_without_mask[0, :, :].detach().cpu().numpy())
+                                          result_without_mask[0, :, :].detach().cpu().numpy(), 6)


### PR DESCRIPTION
The test `MultiHeadSelfAttentionTest::test_multi_head_self_attention_respects_masking` in `pymagnitude/third_party/allennlp/tests/modules/seq2seq_encoders/multi_head_self_attention_test.py` fails intermittently with the following assertion error:

```
E       AssertionError:                                                                                                                                                                                            
E       Arrays are not almost equal to 7 decimals                                                                                                                                                                  
E                                                                                                                                                                                                                  
E       Mismatched elements: 1 / 30 (3.33%)                                                                                                                                                                        
E       Max absolute difference: 2.3841858e-07                                                                                                                                                                     
E       Max relative difference: 4.042717e-06                                                                                                                                                                      
E        x: array([[-0.352625 ,  0.1294522, -0.6926192, -0.1527835, -0.1780743],                                                                                                                                   
E              [-0.403197 ,  0.16395  , -0.654655 , -0.1818076, -0.2412511],                                                                                                                                       
E              [-0.4987849,  0.0612553, -0.7484417, -0.2248259, -0.2507692],...                                                                                                                                    
E        y: array([[-0.352625 ,  0.1294521, -0.6926192, -0.1527835, -0.1780743],                                                                                                                                   
E              [-0.403197 ,  0.16395  , -0.654655 , -0.1818076, -0.2412511],                                                                                                                                       
E              [-0.498785 ,  0.0612553, -0.7484417, -0.2248259, -0.2507692],...    
```

This fix addresses this problem. I looked at the differences in the values that are being compared from several samples and changing the decimal places from 7 (default) to 6 fixes this problem and reduces the flakiness of the test.

Please let me know if this looks good or if you have any other suggestions for the fix.
