### PR TITLE
Flaky test fix

### DIFF
--- a/pymagnitude/third_party/allennlp/tests/modules/seq2seq_encoders/multi_head_self_attention_test.py
+++ b/pymagnitude/third_party/allennlp/tests/modules/seq2seq_encoders/multi_head_self_attention_test.py
@@ -41,4 +41,4 @@ class MultiHeadSelfAttentionTest(AllenNlpTestCase):
         # only the unmasked elements - should be the same.
         result_without_mask = attention(tensor[:, :6, :])
         numpy.testing.assert_almost_equal(result[0, :6, :].detach().cpu().numpy(),
-                                          result_without_mask[0, :, :].detach().cpu().numpy())
+                                          result_without_mask[0, :, :].detach().cpu().numpy(),6)


### PR DESCRIPTION
The test `test_multi_head_self_attention_respects_masking` sometimes fails non-deterministically. It seems the assertion uses a higher precision that required in this case. This PR fixes this issue.

To find a solution, I collected samples from several test executions and computed the tail distribution. I computed the extreme percentiles to check how high can the values be. Using the 99.99th percentile, I observed that the relative difference between the compared values seem to be >1e-7 but < 1e-6. Hence, I am setting the decimal places to 6 in this case.

I think setting the bound using the statistical evaluation might be a good way to ensure the test is not flaky.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions. Also, here I assume there are no bugs in the code under test.


