### PR TITLE
fix MutableMapping import error #92

### DIFF
--- a/pymagnitude/third_party/allennlp/common/params.py
+++ b/pymagnitude/third_party/allennlp/common/params.py
@@ -9,7 +9,8 @@ logging and validation.
 from __future__ import with_statement
 from __future__ import absolute_import
 #typing
-from collections import MutableMapping, OrderedDict
+from collections import OrderedDict
+from collections.abc import MutableMapping
 import copy
 import json
 import logging


### PR DESCRIPTION
I read the issue [#92](https://github.com/plasticityai/magnitude/issues/92).
I confirmed thea pymagnitude work well when fix code like the solution in the issue.

So if there no problems in this fix, I'm grad to merge this pull request.
Thank you.
